### PR TITLE
Only allow ++/-- at the end of the word

### DIFF
--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -36,7 +36,7 @@ module.exports = (robot) ->
   robot.brain.data.karma ?= {}
 
   # listen for @username++ or @username-- (and now also just "username++/--")
-  robot.hear /(@)?[a-z0-9]*(?:[\+]{2}|[\-]{2})/ig, (msg) ->
+  robot.hear /(@)?[a-z0-9]*(?:[\+]{2}|[\-]{2})\B/ig, (msg) ->
 
     user_scores = {}
 


### PR DESCRIPTION
Currently it's tagging something++this as a ++ for something, which might be in an URL, or any other scenario, this change ads the condition that there needs a word break after the ++/-- you can see https://www.regexpal.com/?fam=106097 for tests executed with this new regular expression.